### PR TITLE
Added the new LDA topic modeling feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@
 
 # RStudio files
 .Rproj.user/
+.Rproj.user
+*.Rproj

--- a/cleaning2.R
+++ b/cleaning2.R
@@ -21,6 +21,9 @@ filelist <- list.files("input", full.names = T)
 # Remove possible old literature data frame
 rm(literature)
 
+# Check whether to use topic modeling
+enableTM <- file.exists('enabletm')
+
 # Load files in the input folder and merge into a single file
 # Ugly but works. 
 for (file in filelist) {
@@ -207,6 +210,30 @@ literature$CoreLiterature <- FALSE
 
 # Remove duplicates
 literature <- literature[!duplicated(literature[, "ReferenceString"]), ]
+
+###############################################################################
+
+# Do if topicmodeling enabled
+
+if (enableTM) {
+  # Do topic modeling on abstracts using the lda libraries (adding them as a new column)
+  source("topicmodel.R", chdir = T)
+  
+  # Add top topic to main document
+  literature$TopicModelTopic <- tfdDF$toptopic
+  
+  # Save the topic model topic descriptions
+  write.table(topwords, "output/topicmodeltopics.csv", 
+              sep = ";", row.names = F, qmethod = "double")
+  
+  # HTML output
+  serVis(json, out.dir = 'output/topicmodelvis', open.browser = FALSE)
+  
+  # Freeing up memory
+  rm(json)
+}
+
+###############################################################################
 
 # Save the literature as a single csv-file literature.csv.
 write.table(literature, "output/literature.csv", 

--- a/exploration.Rmd
+++ b/exploration.Rmd
@@ -328,3 +328,20 @@ topRef <- topRef[with (topRef, order(-InDegree, -PageRank)), ]
 kable(topRef[, c("FullReference", "InDegree", "PageRank")])
 ```
 
+```{r, results='asis', echo=FALSE}
+if (enableTM) {
+cat('### Topic modeling output
+[Topic modeling](https://en.wikipedia.org/wiki/Topic_model) is a type of statistical text mining method for discovering common "topics" that occur in a collection of documents. A topic modeling algorithm essentially looks through the abstracts included in the datasets for clusters of co-occurring of words and groups them together by a process of similarity.
+
+The following columns describe each topic detected using [LDA topic modeling](http://blog.echen.me/2011/08/22/introduction-to-latent-dirichlet-allocation/) by listing the ten most characteristic words in each topic. See also the [interactive visualization](output/topicmodelvis/index.html) for a better characterization of the topics and a visual representation of how (dis)similar the detected topics are to each other.
+')
+}
+```
+
+```{r, echo=FALSE}
+if (enableTM) {
+  tw <- data.frame(topwords)
+  colnames(tw) <- gsub('X', 'Topic ', colnames(tw))
+  kable(tw, col.names = colnames(tw))
+}
+```

--- a/topicmodel.R
+++ b/topicmodel.R
@@ -1,0 +1,109 @@
+###############################################################################
+
+# Do topic modeling on abstracts using the lda libraries
+# Do not use alone (loaded from the cleaning2.R)
+
+# Libraries
+library(tm)
+library(SnowballC)
+library(lda)
+library(LDAvis)
+# Enable multicore processing (works only on *NIX-based systems)
+#library(doMC)
+#registerDoMC(4)
+
+# Import data (see cleaning2.R)
+data <- literature$Abstract
+
+# read in English stopwords from the SMART collection
+stop_words <- stopwords("SMART")
+
+# pre-processing (remove stopwords; destem)
+data <- gsub("'", "", data)  # remove apostrophes
+data <- gsub("[[:punct:]]", " ", data)  # replace punctuation with space
+data <- gsub("[[:cntrl:]]", " ", data)  # replace control characters with space
+data <- gsub("^[[:space:]]+", "", data) # remove whitespace at beginning of documents
+data <- gsub("[[:space:]]+$", "", data) # remove whitespace at end of documents
+data <- tolower(data)  # force to lowercase
+data <- stemDocument(data)
+
+# tokenize on space and output as a list
+doc.list <- strsplit(data, "[[:space:]]+")
+
+# compute the table of terms
+term.table <- table(unlist(doc.list))
+term.table <- sort(term.table, decreasing = TRUE)
+
+# remove terms that are stop words or occur fewer than 5 times
+del <- names(term.table) %in% stop_words | term.table < 5
+term.table <- term.table[!del]
+del2 <- grepl("^\\d+$", names(term.table)) # remove words that are only numbers
+term.table <- term.table[!del2]
+vocab <- names(term.table)
+
+# now put the documents into the format required by the lda package
+get.terms <- function(x) {
+  index <- match(x, vocab)
+  index <- index[!is.na(index)]
+  rbind(as.integer(index - 1), as.integer(rep(1, length(index))))
+}
+# mclapply is the multicore enabled version of lapply
+documents <- lapply(doc.list, get.terms)
+
+# Compute some statistics related to the data set:
+D <- length(documents)  # number of documents (2,000)
+W <- length(vocab)  # number of terms in the vocab (14,568)
+doc.length <- sapply(documents, function(x) sum(x[2, ]))  # number of tokens per document [312, 288, 170, 436, 291, ...]
+N <- sum(doc.length)  # total number of tokens in the data (546,827)
+term.frequency <- as.integer(term.table)  # frequencies of terms in the corpus [8939, 5544, 2411, 2410, 2143, ...]
+
+# MCMC and model tuning parameters
+K <- 5 # number of topics 
+G <- 2500 # iterations
+alpha <- 0.2 # 1 / K
+eta <- 0.2 # 1 / K
+
+# Fit the model
+set.seed(357)
+
+fit <- lda.collapsed.gibbs.sampler(documents = documents, K = K, vocab = vocab, 
+                                   num.iterations = G, alpha = alpha, 
+                                   eta = eta, initial = NULL, burnin = 0,
+                                   compute.log.likelihood = TRUE)
+
+# Document topic matrix (transposed to get topic probabilities for each document)
+topicsfordocs <- t(fit$document_sums)
+# Convert to data frame
+tfdDF <- data.frame(topicsfordocs)
+# Add top topics document
+tfdDF$toptopic <- colnames(tfdDF)[max.col(tfdDF,ties.method="first")]
+
+# Summary statistics
+# Most likely documents for each topic
+topdocsfortopic <- top.topic.documents(fit$document_sums)
+# Ten most likely words for each topic
+topwords <- top.topic.words(fit$topics, 10, by.score = TRUE)
+
+theta <- t(apply(fit$document_sums + alpha, 2, function(x) x/sum(x)))
+phi <- t(apply(t(fit$topics) + eta, 2, function(x) x/sum(x)))
+
+TopicModel    <- list(phi = phi,
+                      theta = theta,
+                      doc.length = doc.length,
+                      vocab = vocab,
+                      term.frequency = term.frequency)
+
+
+# create the JSON object to feed the visualization
+json <- createJSON(phi = TopicModel$phi, 
+                   theta = TopicModel$theta, 
+                   doc.length = TopicModel$doc.length, 
+                   vocab = TopicModel$vocab, 
+                   term.frequency = TopicModel$term.frequency)
+
+# Freeing up memory
+rm(data)
+rm(documents)
+rm(vocab)
+rm(TopicModel)
+rm(fit)


### PR DESCRIPTION
I think the topicmodeling feature is now mature enough to include in the main branch. There's also a file-exists -based check (if enabletm-file exists) to enable/disable the feature, so the user is not forced to run the analysis. The feature is disabled by default for now.

Opinions? If there are no objections, I'll go ahead with the merge. Because of the switch to enable/disable the feature, there is no impact on the ordinary use of the feature.
